### PR TITLE
Using an archive version of rgoogleslides

### DIFF
--- a/base_ottr/Dockerfile
+++ b/base_ottr/Dockerfile
@@ -85,10 +85,7 @@ RUN Rscript -e  "devtools::install_version('gitcreds', version = '0.1.1', repos 
 #rgoogleslides archived version from CRAN
 RUN Rscript -e  "options(warn = 2);install.packages( \
     'https://cran.r-project.org/src/contrib/Archive/rgoogleslides/rgoogleslides_0.3.2.tar.gz')"
-
-# Install the 'remotes' package from CRAN
-RUN R -e "install.packages('remotes', repos = 'https://cran.rstudio.com/')"
-
+    
 RUN installGithub.r \
   ottrproject/ottrpal
 


### PR DESCRIPTION
Had been testing a branch of ottrpal with this branch and found that rgoogleslides is no longer on CRAN and we needed an archive version as discussed in Issue #10 . Back to main branch ottrpal now that the dev there has been merged (related: https://github.com/ottrproject/ottrpal/pull/12).  So there's a few commits here adding and removing installing remotes and ottrpal from a branch (but we don't need that anymore)