### PR TITLE
add cow back to base ottr

### DIFF
--- a/base_ottr/Dockerfile
+++ b/base_ottr/Dockerfile
@@ -84,7 +84,8 @@ RUN gdebi --non-interactive quarto-linux-amd64.deb
 RUN Rscript -e  "devtools::install_version('gitcreds', version = '0.1.1', repos = 'http://cran.us.r-project.org')"
 
 RUN installGithub.r \
-  ottrproject/ottrpal
+  ottrproject/ottrpal \
+  jhudsl/cow
 
 # Set final workdir for commands
 WORKDIR /home/rstudio


### PR DESCRIPTION
Adding cow back to the base_ottr image so that it's here until we switch over to the ottrpal::borrow_chapter